### PR TITLE
Feat/endpoint login jwt o sesion

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -129,11 +129,16 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Configuración de JWT
+
 from datetime import timedelta
+
+# Definir el tipo de autenticación que se va a usar
+AUTH_TYPE = 'JWT'
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication", # Para JWT
+        "rest_framework.authentication.SessionAuthentication", # Para sesiones
     ),
     "DEFAULT_PERMISSION_CLASSES": (
         "rest_framework.permissions.IsAuthenticated",
@@ -143,6 +148,8 @@ REST_FRAMEWORK = {
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=60),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
+    "ROTATE_REFRESH_TOKENS": True,
+    "BLACKLIST_AFTER_ROTATION": True,
 }
 
 CORS_ALLOWED_ORIGINS = [

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -39,7 +39,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'weather'
+    'weather',
+    'rest_framework',
+    'rest_framework_simplejwt' # <-- Dependencia para los tokens (JWT)
 ]
 
 MIDDLEWARE = [
@@ -126,6 +128,7 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+# Configuración de JWT
 from datetime import timedelta
 
 REST_FRAMEWORK = {

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -2,18 +2,16 @@ from django.contrib import admin
 from django.urls import path, include
 
 from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
     TokenRefreshView,
 )
 
 urlpatterns = [
     path("admin/", admin.site.urls),
 
-    # Auth JWT: login y refresh
-    path("api/auth/login/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    # Auth JWT: refresh token
     path("api/auth/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
 
-    # Rutas de registro / me / admin-only
+    # Rutas de autenticación (registro, login, me, admin-only)
     path("api/auth/", include("users.urls")),
 
     # Weather Prophet forecasts

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -65,6 +65,7 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         return ProfileSerializer(instance).data
 
+# Añadido serializer para login
 class LoginSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password = serializers.CharField(write_only=True)
@@ -80,6 +81,7 @@ class LoginSerializer(serializers.Serializer):
 
             try:
                 user = User.objects.get(email=email)
+                username = user.username
                 # Verificar contraseña
                 if not user.check_password(password):
                     raise serializers.ValidationError('Credenciales incorrectas')
@@ -89,6 +91,21 @@ class LoginSerializer(serializers.Serializer):
             if not user.is_active:
                 raise serializers.ValidationError('Usuario desactivado')
             
+            # Usar authenticate() para verificar credenciales
+            user = authenticate(username=username, password=password)
+
+            if user is None:
+                raise serializers.ValidationError(
+                    'Credenciales inválidas',
+                    code='authentication_failed'
+                )
+            
+            if not user.is_active:
+                raise serializers.ValidationError(
+                    'Esta cuenta ha sido desactivada',
+                    code='account_disabled'
+                )
+
             data['user'] = user
         
         else:

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -82,14 +82,8 @@ class LoginSerializer(serializers.Serializer):
             try:
                 user = User.objects.get(email=email)
                 username = user.username
-                # Verificar contraseña
-                if not user.check_password(password):
-                    raise serializers.ValidationError('Credenciales incorrectas')
             except User.DoesNotExist:
                 raise serializers.ValidationError('Credenciales incorrectas')
-            
-            if not user.is_active:
-                raise serializers.ValidationError('Usuario desactivado')
             
             # Usar authenticate() para verificar credenciales
             user = authenticate(username=username, password=password)

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 from django.core.validators import validate_email
 from rest_framework import serializers
+from django.contrib.auth import authenticate
 
 
 class UserRegisterSerializer(serializers.ModelSerializer):
@@ -64,3 +65,33 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         return ProfileSerializer(instance).data
 
+class LoginSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True)
+
+    def validate(self, data):
+        email = data.get('email')
+        password = data.get('password')
+
+        if email and password:
+            # Buscar usuario por email
+            from django.contrib.auth import get_user_model
+            User = get_user_model()
+
+            try:
+                user = User.objects.get(email=email)
+                # Verificar contraseña
+                if not user.check_password(password):
+                    raise serializers.ValidationError('Credenciales incorrectas')
+            except User.DoesNotExist:
+                raise serializers.ValidationError('Credenciales incorrectas')
+            
+            if not user.is_active:
+                raise serializers.ValidationError('Usuario desactivado')
+            
+            data['user'] = user
+        
+        else:
+            raise serializers.ValidationError('Debe proporcionar email y contraseña')
+        
+        return data

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -41,18 +41,20 @@ class AuthenticationTests(TestCase):
         # Crear usuario
         user = User.objects.create_user(
             username='testuser',
-            password='testpass123'
+            password='testpass123',
+            email='test@example.com'
         )
         
         # Intentar login
         data = {
-            'username': 'testuser',
+            'email': 'test@example.com',
             'password': 'testpass123'
         }
         response = self.client.post(self.login_url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('access', response.data)
-        self.assertIn('refresh', response.data)
+        self.assertIn('tokens', response.data)
+        self.assertIn('access', response.data['tokens'])
+        self.assertIn('refresh', response.data['tokens'])
 
     def test_me_endpoint_requires_authentication(self):
         """Test: Endpoint /me/ requiere autenticación"""
@@ -69,11 +71,11 @@ class AuthenticationTests(TestCase):
         )
         
         login_data = {
-            'username': 'testuser',
+            'email': 'test@example.com',
             'password': 'testpass123'
         }
         login_response = self.client.post(self.login_url, login_data, format='json')
-        token = login_response.data['access']
+        token = login_response.data['tokens']['access']
         
         # Usar token para acceder a /me/
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,11 +1,13 @@
 from django.urls import path
 from .views import (
     RegisterView, MeView, ProfileView,
-    AdminOnlyView, SuperuserOnlyView, PublicView
+    AdminOnlyView, SuperuserOnlyView, PublicView,
+    LoginView
 )
 
 urlpatterns = [
     path("register/", RegisterView.as_view(), name="register"),
+    path("login/", LoginView.as_view(), name="login"),
     path("me/", MeView.as_view(), name="me"),
     path("profile/", ProfileView.as_view(), name="profile"),
     path("admin-only/", AdminOnlyView.as_view(), name="admin-only"),

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,13 +1,24 @@
 from django.contrib.auth.models import User
-from rest_framework import generics, permissions
+from rest_framework.views import APIView
+from rest_framework import generics, permissions, status
 from rest_framework.response import Response
+from django.contrib.auth import login
+from django.conf import settings
 
 from .serializers import (
     UserRegisterSerializer,
     ProfileSerializer,
     ProfileUpdateSerializer,
+    LoginSerializer,
 )
 from .permissions import IsSuperUser
+
+# Solo importar FWT si está disponible
+try:
+    from rest_framework_simplejwt.tokens import RefreshToken
+    JWT_AVAILABLE = True
+except ImportError:
+    JWT_AVAILABLE = False
 
 
 class RegisterView(generics.CreateAPIView):
@@ -55,3 +66,81 @@ class PublicView(generics.GenericAPIView):
 
     def get(self, request):
         return Response({"message": "Este es un endpoint público."})
+
+class LoginView(APIView):
+    """
+    Endpoint de autenticación de usuarios.
+    Soporta tanto JWT como sesiones tradicionales de Django.
+    """
+    permission_classes = [permissions.AllowAny]
+    serializer_class = LoginSerializer
+
+    def post(self, request):
+        """
+        Autentica un usuario con email y contraseña.
+        El tipo de autenticación se determina por la configuración AUTH_TYPE.
+        """
+        serializer = LoginSerializer(data=request.data)
+
+        if serializer.is_valid():
+            user = serializer.validated_data['user']
+
+            # Determinar el tipo de autenticación según settings
+            auth_type = getattr(settings, 'AUTH_TYPE', 'SESSION')
+
+            if auth_type == 'JWT' and JWT_AVAILABLE:
+                return self._handle_jwt_login(user)
+            else:
+                return self._handle_session_login(request, user)
+            
+        # Si el serializer no es válido, devuelve errores
+        return Response(
+            {
+                'ERROR': 'Autenticación fallida',
+                'detail': serializer.errors
+            },
+            status=status.HTTP_401_UNAUTHORIZED
+        )
+    
+    def _handle_jwt_login(self, user):
+        """
+        Maneja login con JWT
+        """
+        refresh = RefreshToken.for_user(user)
+
+        return Response({
+            "success": True,
+            "message": "Autenticación exitosa",
+            "auth_type": "JWT",
+            "tokens": {
+                "refresh": str(refresh),
+                "access": str(refresh.access_token),
+            },
+            "user": {
+                "id": user.id,
+                "username": user.username,
+                "email": user.email,
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+            }
+        }, status=status.HTTP_200_OK)
+
+    def _handle_session_login(self, request, user):
+        """
+        Maneja login con sesión tradicional
+        """
+        login(request, user)
+
+        return Response({
+            'success': True,
+            'message': 'Autenticación exitosa',
+            'auth_type': 'SESSION',
+            'session_id': request.session.session_key,
+            'user': {
+                'id': user.id,
+                'username': user.username,
+                'email': user.email,
+                'first_name': user.first_name,
+                'last_name': user.last_name,
+            }
+        }, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ¿Qué hace este PR?

<!-- Describe en 2-3 líneas qué cambia -->
He creado una clase en 'serializers.py' para verificar las credenciales del usuario con 'authenticte()' 
También he creado un endpoint en 'views.py' que sirve para soportar tanto JWT como sesiones tradicionales de Django.

## Tipo de cambio

- [X] ✨ Nueva funcionalidad
- [ ] 🐛 Corrección de bug
- [ ] 💄 Cambios de estilo/CSS
- [ ] 📝 Documentación

## Checklist

- [X] El código funciona en local
- [ ] No subí archivos `.env` ni credenciales
- [X] Revisé mi código antes de pedir revisión

## ¿Cómo lo pruebo?

1.  Una vez dentro de la terminal en el repositorio, accede al directorio 'backend'.
2.  Luego ejecuta 'python manage.py runserver' y accede a este enlace: 'localhost:8000'.
3. Después dirige la ruta de localhost:8000 hacia "/api/auth/login" (Saltar al paso 6).
4. Si no tienes username, dirigete a la siguiente ruta: "/api/auth/register".
5. Introduce su nombre de usuario (username), cuenta de correo(email), una contraseña (password1) y de nuevo la contraseña (password2).
6. Una vez en /api/auth/login, accede con su username y password; y en teoría saldrá mensaje de éxito "HTTP 200 OK".

## Capturas (si aplica)

<!-- Añade capturas si hay cambios visuales -->

<img width="1447" height="402" alt="Captura de pantalla 2025-12-10 203418" src="https://github.com/user-attachments/assets/141c467a-7fb6-4e2e-bfcd-73283da75f7b" />

